### PR TITLE
Specify solc version in truffle config

### DIFF
--- a/solidity/truffle-config.js
+++ b/solidity/truffle-config.js
@@ -34,5 +34,10 @@ module.exports = {
             enabled: true,
             runs:    200
         }
+    },
+    compilers: {
+	solc: {
+		version: '0.4.24'
+	} 
     }
 };

--- a/solidity/truffle-config.js
+++ b/solidity/truffle-config.js
@@ -37,7 +37,7 @@ module.exports = {
     },
     compilers: {
 	solc: {
-		version: '0.4.24'
+		version: '0.4.26'
 	} 
     }
 };


### PR DESCRIPTION
My default solc in truffle was solidity 0.5.x which made compilation fail since it didn't meet requirement of ^0.4.24.

Furthermore, `truffle` fails to build the contracts with `solc < 0.4.26`:

```
> Compiling ./contracts/utility/interfaces/IWhitelist.sol
RangeError: Maximum call stack size exceeded
    at Object._db [as dynCall_viiiiii] (/home/lash/.config/truffle/compilers/node_modules/soljson-v0.4.24+commit.e67f0147.js:12:120931)
    at invoke_viiiiii (/home/lash/.config/truffle/compilers/node_modules/soljson-v0.4.24+commit.e67f0147.js:1:1117622)
    at Array.ova (/home/lash/.config/truffle/compilers/node_modules/soljson-v0.4.24+commit.e67f0147.js:13:29030)
    at Object.L9a [as dynCall_vi] (/home/lash/.config/truffle/compilers/node_modules/soljson-v0.4.24+commit.e67f0147.js:12:99033)
    at invoke_vi (/home/lash/.config/truffle/compilers/node_modules/soljson-v0.4.24+commit.e67f0147.js:1:1114426)
    at Array.wta (/home/lash/.config/truffle/compilers/node_modules/soljson-v0.4.24+commit.e67f0147.js:10:704789)
    at Object.Cfb [as dynCall_iii] (/home/lash/.config/truffle/compilers/node_modules/soljson-v0.4.24+commit.e67f0147.js:12:130740)
    at invoke_iii (/home/lash/.config/truffle/compilers/node_modules/soljson-v0.4.24+commit.e67f0147.js:1:1118857)
    at Array.uta (/home/lash/.config/truffle/compilers/node_modules/soljson-v0.4.24+commit.e67f0147.js:10:703085)
    at Object.Xfb [as dynCall_iiiiii] (/home/lash/.config/truffle/compilers/node_modules/soljson-v0.4.24+commit.e67f0147.js:12:131900)
    at invoke_iiiiii (/home/lash/.config/truffle/compilers/node_modules/soljson-v0.4.24+commit.e67f0147.js:1:1119107)
    at yua (/home/lash/.config/truffle/compilers/node_modules/soljson-v0.4.24+commit.e67f0147.js:10:861324)
    at qra (/home/lash/.config/truffle/compilers/node_modules/soljson-v0.4.24+commit.e67f0147.js:10:535869)
    at Array.oqa (/home/lash/.config/truffle/compilers/node_modules/soljson-v0.4.24+commit.e67f0147.js:10:461143)
    at Object.zhb [as dynCall_iiiii] (/home/lash/.config/truffle/compilers/node_modules/soljson-v0.4.24+commit.e67f0147.js:12:139268)
    at invoke_iiiii (/home/lash/.config/truffle/compilers/node_modules/soljson-v0.4.24+commit.e67f0147.js:1:1120221)
    at Array.Zpa (/home/lash/.config/truffle/compilers/node_modules/soljson-v0.4.24+commit.e67f0147.js:10:406357)
    at Object.wjb [as dynCall_viiii] (/home/lash/.config/truffle/compilers/node_modules/soljson-v0.4.24+commit.e67f0147.js:12:147059)
    at invoke_viiii (/home/lash/.config/truffle/compilers/node_modules/soljson-v0.4.24+commit.e67f0147.js:1:1121512)
    at Array.Zpa (/home/lash/.config/truffle/compilers/node_modules/soljson-v0.4.24+commit.e67f0147.js:10:403171)
    at Object.wjb [as dynCall_viiii] (/home/lash/.config/truffle/compilers/node_modules/soljson-v0.4.24+commit.e67f0147.js:12:147059)
    at invoke_viiii (/home/lash/.config/truffle/compilers/node_modules/soljson-v0.4.24+commit.e67f0147.js:1:1121512)
Truffle v5.0.31 (core: 5.0.31)
```